### PR TITLE
Pin max librosa version to avoid LGPL dependency

### DIFF
--- a/requirements/audio.txt
+++ b/requirements/audio.txt
@@ -1,3 +1,3 @@
 soundfile~=0.10
-librosa~=0.8,!=0.10
+librosa~=0.8,<0.10
 pydub~=0.25


### PR DESCRIPTION
# Description
librosa 0.10 added `soxr`, an LGPL licensed dependency. This pins a max librosa version to avoid dragging this incompatible license.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->