### PR TITLE
Add email validation util

### DIFF
--- a/neon_utils/parse_utils.py
+++ b/neon_utils/parse_utils.py
@@ -228,3 +228,23 @@ def transliteration(transcription: str, text: str, lang: str) -> (str, str):
             return text
     else:
         return text
+
+
+def validate_email(email_addr: str) -> str:
+    """
+    Check if the passed string is a valid email address and try to parse it
+    into one.
+    :param email_addr: email address to validate
+    :returns: Validated email address or an empty string
+    """
+    email_rx = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b'
+    if re.fullmatch(email_rx, email_addr):
+        return email_addr
+
+    if ' ' in email_addr:
+        LOG.info(f"Removing whitespace from email address")
+        email_addr = email_addr.replace(' ', '')
+        if re.fullmatch(email_rx, email_addr):
+            return email_addr
+
+    return ""

--- a/tests/parse_util_tests.py
+++ b/tests/parse_util_tests.py
@@ -168,6 +168,13 @@ class ParseUtilTests(unittest.TestCase):
         tagged_with_exclusion = format_speak_tags("Don't<speak>Speak This.</speak>But Not this.", False)
         self.assertEqual(tagged_with_exclusion, valid_output)
 
+    def test_validate_email(self):
+        from neon_utils.parse_utils import validate_email
+        valid = "developers@neon.ai"
+        self.assertEqual(validate_email(valid), valid)
+        self.assertEqual(validate_email(f" {valid} "), valid)
+        self.assertEqual(validate_email("developers @ neon. ai"), valid)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/parse_util_tests.py
+++ b/tests/parse_util_tests.py
@@ -175,6 +175,11 @@ class ParseUtilTests(unittest.TestCase):
         self.assertEqual(validate_email(f" {valid} "), valid)
         self.assertEqual(validate_email("developers @ neon. ai"), valid)
 
+        self.assertEqual(validate_email(" not an email address"), "")
+        self.assertEqual(validate_email("test@neon"), "")
+        self.assertEqual(validate_email("test@neon. "), "")
+        self.assertEqual(validate_email("neon.ai"), "")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description
Adds `parse_utils.validate_email` to check for a valid email address and do minimal parsing to make the passed string valid.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->