### PR TITLE
Remove ovos core dependency

### DIFF
--- a/neon_utils/skills/common_play_skill.py
+++ b/neon_utils/skills/common_play_skill.py
@@ -46,7 +46,7 @@ from abc import ABC, abstractmethod
 from ovos_bus_client import Message
 from neon_utils.skills.neon_skill import NeonSkill
 
-from mycroft.skills.audioservice import AudioService
+from ovos_utils.skills.audioservice import AudioServiceInterface as AudioService
 
 
 class CPSMatchLevel(Enum):

--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -288,7 +288,7 @@ class NeonSkill(PatchedMycroftSkill):
         voc = resolve_neon_resource_file(f"text/{lang}/{voc_filename}.voc")
         if not voc:
             raise FileNotFoundError(voc)
-        from mycroft.skills.skill_data import read_vocab_file
+        from ovos_utils.file_utils import read_vocab_file
         from itertools import chain
         import re
         vocab = read_vocab_file(voc)

--- a/neon_utils/validator_utils.py
+++ b/neon_utils/validator_utils.py
@@ -26,7 +26,6 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from neon_utils import LOG
 from lingua_franca import parse, set_default_lang
 
 from ovos_workshop.skills.mycroft_skill import MycroftSkill

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-timeout
 pytest-cov
 mock
-# ovos-core~=0.0.7,>=0.0.8a21
+ovos-core~=0.0.7,>=0.0.8a21
 ovos-plugin-manager~=0.0.18
 ovos-skills-manager
 neon-lang-plugin-libretranslate

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,6 +2,7 @@ pytest
 pytest-timeout
 pytest-cov
 mock
+# TODO: Deprecate ovos-core test dependency
 ovos-core~=0.0.7,>=0.0.8a21
 ovos-plugin-manager~=0.0.18
 ovos-skills-manager

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-timeout
 pytest-cov
 mock
-ovos-core[skills,skills_lgpl]
-ovos-plugin-manager~=0.0.17
+ovos-core[skills,skills_lgpl]~=0.0.7
+ovos-plugin-manager~=0.0.18
 ovos-skills-manager
 neon-lang-plugin-libretranslate

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-timeout
 pytest-cov
 mock
-ovos-core[skills,skills_lgpl]~=0.0.7
+ovos-core~=0.0.7,>=0.0.8a21
 ovos-plugin-manager~=0.0.18
 ovos-skills-manager
 neon-lang-plugin-libretranslate

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-timeout
 pytest-cov
 mock
-ovos-core~=0.0.7,>=0.0.8a21
+# ovos-core~=0.0.7,>=0.0.8a21
 ovos-plugin-manager~=0.0.18
 ovos-skills-manager
 neon-lang-plugin-libretranslate

--- a/tests/skills/__init__.py
+++ b/tests/skills/__init__.py
@@ -33,10 +33,10 @@ from neon_utils.skills import CommonMessageSkill, CommonPlaySkill,\
     InstructorSkill, KioskSkill
 
 import importlib
-import mycroft.skills
-mycroft.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
-importlib.reload(mycroft.skills.fallback_skill)
-from mycroft.skills.fallback_skill import FallbackSkill
+# import mycroft.skills
+# mycroft.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
+# importlib.reload(mycroft.skills.fallback_skill)
+# from mycroft.skills.fallback_skill import FallbackSkill
 
 
 class TestCMS(CommonMessageSkill):

--- a/tests/skills/__init__.py
+++ b/tests/skills/__init__.py
@@ -32,6 +32,10 @@ from neon_utils.skills import CommonMessageSkill, CommonPlaySkill,\
     CommonQuerySkill, NeonFallbackSkill, NeonSkill, PatchedMycroftSkill,\
     InstructorSkill, KioskSkill
 
+import ovos_workshop.skills.ovos
+ovos_workshop.skills.ovos.MycroftSkill = PatchedMycroftSkill
+from ovos_workshop.skills.fallback import FallbackSkill
+
 
 class TestCMS(CommonMessageSkill):
     def __init__(self):

--- a/tests/skills/__init__.py
+++ b/tests/skills/__init__.py
@@ -32,12 +32,6 @@ from neon_utils.skills import CommonMessageSkill, CommonPlaySkill,\
     CommonQuerySkill, NeonFallbackSkill, NeonSkill, PatchedMycroftSkill,\
     InstructorSkill, KioskSkill
 
-import importlib
-# import mycroft.skills
-# mycroft.skills.mycroft_skill.MycroftSkill = PatchedMycroftSkill
-# importlib.reload(mycroft.skills.fallback_skill)
-# from mycroft.skills.fallback_skill import FallbackSkill
-
 
 class TestCMS(CommonMessageSkill):
     def __init__(self):


### PR DESCRIPTION
# Description
Refactor package to import from ovos-workshop and ovos-utils to remove `mycrfot` imports

# Issues
Relates to #469 

# Other Notes
`ovos-core` is still listed as a test dependency as some tests are failing without it. Failures appear to be related to configuration handling, but are not immediately resolvable so this will be left to a future PR, possibly after some of the configuration marked for deprecation is actually deprecated