### PR TITLE
Add call to `init_config_dir` in legacy setup config handling

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -1042,6 +1042,7 @@ def create_config_from_setup_params(path=None) -> dict:
     Returns:
         NGIConfig object generated from environment vars
     """
+    init_config_dir()
 
     dev_mode = (os.environ.get("devMode") or "false") == "true"
     # auto_run = os.environ.get("autoStart") or "false" == "true"


### PR DESCRIPTION
# Description
Ensure config directory is initialized when writing config from legacy setup script

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->