### PR TITLE
Patch multiple native languages intent registration

### DIFF
--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -892,3 +892,14 @@ class NeonSkill(BaseSkill):
         """
         log_deprecation("Use `load_dialog_files`", "2.0.0")
         self.load_dialog_files(root_directory)
+
+    def add_event(self, name: str, handler: callable,
+                  handler_info: Optional[str] = None, once: bool = False,
+                  speak_errors: bool = True):
+        # TODO: Remove with ovos-workshop==0.0.13
+        if handler_info == "mycroft.skill.handler" and \
+                self.bus.emitter.listeners(name):
+            LOG.warning(f"Not re-registering intent handler {name}")
+            return
+        BaseSkill.add_event(self, name, handler, handler_info, once,
+                            speak_errors)


### PR DESCRIPTION
# Description
Temporarily patches `add_event` to prevent multiple listeners for the same skill

# Issues
Proper fix: https://github.com/OpenVoiceOS/OVOS-workshop/pull/148

# Other Notes
Temporarily patching for immediate NeonOS update and in case a NeonCore stable release is needed before a stable ovos-workshop