### PR TITLE
Better default profile handling

### DIFF
--- a/neon_utils/user_utils.py
+++ b/neon_utils/user_utils.py
@@ -102,9 +102,13 @@ def get_user_prefs(message: Message = None) -> dict:
         return default_user_config
 
     for profile in message.context.get(profile_key):
-        if profile["user"]["username"] == username:
-            return dict(dict_update_keys(profile, default_user_config))
+        try:
+            if profile["user"]["username"] == username:
+                return dict(dict_update_keys(profile, default_user_config))
+        except KeyError:
+            LOG.error(f"Malformed profile in message context: {profile}")
     LOG.warning(f"No preferences found for {username} in {message.context}")
+    default_user_config['user']['username'] = username
     return default_user_config
 
 

--- a/tests/user_util_tests.py
+++ b/tests/user_util_tests.py
@@ -66,6 +66,15 @@ class UserUtilTests(unittest.TestCase):
         self.assertIn("address", user_2["user"])
         self.assertEqual(test_message_2.context['user_profiles'][1], user_2)
 
+        missing_profile = get_user_prefs(Message("", {},
+                                                 {"username": "test",
+                                                  "user_profiles": [{}]}))
+        self.assertEqual(missing_profile["user"]["username"], "test")
+        missing_profile_2 = get_user_prefs(Message("", {},
+                                                   {"username": "test2",
+                                                    "user_profiles": [{}]}))
+        self.assertEqual(missing_profile_2["user"]["username"], "test2")
+
         def wrapper(message, valid_dict):
             self.assertEqual(get_user_prefs(), valid_dict)
 


### PR DESCRIPTION
# Description
Handle malformed `user_profiles` Message context with fallback to default user config

# Issues
Relates to issue with Time skill seen in https://github.com/NeonGeckoCom/neon-iris/pull/51

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->