### PR TITLE
Use OpenStreetMap geocoder to work around maps.co API changes

### DIFF
--- a/neon_utils/location_utils.py
+++ b/neon_utils/location_utils.py
@@ -39,7 +39,7 @@ from ovos_utils.log import LOG
 
 
 # geocode.maps.co nominatim.openstreetmap.org
-_NOMINATIM_DOMAIN = "geocode.maps.co"
+_NOMINATIM_DOMAIN = "nominatim.openstreetmap.org"
 
 
 def set_nominatim_domain(domain: str):


### PR DESCRIPTION
# Description
As of 12/25, maps.co now [requires API keys](https://geocode.maps.co/) which are not easily added to geopy. Longer-term, I think geolocation should be added to `neon-api-proxy` as other paid/metered services are but the API change has broken stable releases without warning

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->