### PR TITLE
Add utilities for interfacing with Neon HANA

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,164 +63,173 @@ jobs:
         run: |
           sudo chown -R nobody:nogroup tests/configuration/unwritable_path
 
-      - name: Test Utils
+      - name: Test Parse Utils
         run: |
-          pytest tests/ --doctest-modules --junitxml=tests/util-test-results.xml
-      - name: Upload utils test results
+          pytest tests/parse_util_tests.py --doctest-modules --junitxml=tests/parse-util-test-results.xml
+      - name: Upload parse utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: parse-util-test-results
+          path: tests/parse-util-test-results.xml
+
+      - name: Test Web Utils
+        run: |
+          pytest tests/web_util_tests.py --doctest-modules --junitxml=tests/web-util-test-results.xml
+      - name: Upload web utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-util-test-results
+          path: tests/web-util-test-results.xml
+
+      - name: Test Net Utils
+        run: |
+          pytest tests/net_util_tests.py --doctest-modules --junitxml=tests/net-util-test-results.xml
+      - name: Upload net utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: net-util-test-results
+          path: tests/net-util-test-results.xml
+
+      - name: Test Search Utils
+        run: |
+          pytest tests/search_util_tests.py --doctest-modules --junitxml=tests/search-util-test-results.xml
+      - name: Upload search utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: search-util-test-results
+          path: tests/search-util-test-results.xml
+
+      - name: Test Location Utils
+        run: |
+          pytest tests/location_util_tests.py --doctest-modules --junitxml=tests/location-util-test-results.xml
+      - name: Upload location utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: location-util-test-results
+          path: tests/location-util-test-results.xml
+
+      - name: Test Configuration Utils
+        run: |
+          pytest tests/configuration_util_tests.py --doctest-modules --junitxml=tests/configuration-util-test-results.xml
+      - name: Upload configuration utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: configuration-util-test-results
+          path: tests/configuration-util-test-results.xml
+
+      - name: Test Message Utils
+        run: |
+          pytest tests/message_util_tests.py --doctest-modules --junitxml=tests/message-util-test-results.xml
+      - name: Upload message utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: message-util-test-results
+          path: tests/message-util-test-results.xml
+
+      - name: Test Log Utils
+        run: |
+          pytest tests/log_util_tests.py --doctest-modules --junitxml=tests/log-util-test-results.xml
+      - name: Upload log utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: log-util-test-results
+          path: tests/log-util-test-results.xml
+
+      - name: Test Packaging Utils
+        run: |
+          pytest tests/packaging_util_tests.py --doctest-modules --junitxml=tests/packaging-util-test-results.xml
+      - name: Upload packaging utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: packaging-util-test-results
+          path: tests/packaging-util-test-results.xml
+
+      - name: Test Authentication Utils
+        run: |
+          pytest tests/authentication_util_tests.py --doctest-modules --junitxml=tests/authentication-util-test-results.xml
+      - name: Upload authentication utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: authentication-util-test-results
+          path: tests/authentication-util-test-results.xml
+
+      - name: Test Metric Utils
+        run: |
+          pytest tests/metric_util_tests.py --doctest-modules --junitxml=tests/metric-util-test-results.xml
+      - name: Upload metric utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: metric-util-test-results
+          path: tests/metric-util-test-results.xml
+
+      - name: Test Cache Utils
+        run: |
+          pytest tests/cache_util_tests.py --doctest-modules --junitxml=tests/cache-util-test-results.xml
+      - name: Upload cache utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: cache-util-test-results
+          path: tests/cache-util-test-results.xml
+
+      - name: Test MQ Utils
+        run: |
+          pytest tests/mq_util_tests.py --doctest-modules --junitxml=tests/mq-util-test-results.xml
+      - name: Upload MQ utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: mq-util-test-results
+          path: tests/mq-util-test-results.xml
+
+      - name: Test Validator Utils
+        run: |
+          pytest tests/validator_util_tests.py --doctest-modules --junitxml=tests/validator-util-test-results.xml
+      - name: Upload validator utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: validator-util-test-results
+          path: tests/validator-util-test-results.xml
+
+      - name: Test Signal Utils
+        run: |
+          pytest tests/signal_util_tests.py --doctest-modules --junitxml=tests/signal-util-test-results.xml
+      - name: Upload signal utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: signal-util-test-results
+          path: tests/signal-util-test-results.xml
+
+      - name: Test Messagebus Utils
+        run: |
+          pytest tests/messagebus_util_tests.py --doctest-modules --junitxml=tests/messagebus-util-test-results.xml
+      - name: Upload messagebus utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: messagebus-util-test-results
+          path: tests/messagebus-util-test-results.xml
+
+      - name: Test User Utils
+        run: |
+          pytest tests/user_util_tests.py --doctest-modules --junitxml=tests/user-util-test-results.xml
+      - name: Upload user utils test results
         uses: actions/upload-artifact@v2
         with:
           name: util-test-results
           path: tests/util-test-results.xml
-#
-#      - name: Test Web Utils
-#        run: |
-#          pytest tests/web_util_tests.py --doctest-modules --junitxml=tests/web-util-test-results.xml
-#      - name: Upload web utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: web-util-test-results
-#          path: tests/web-util-test-results.xml
-#
-#      - name: Test Net Utils
-#        run: |
-#          pytest tests/net_util_tests.py --doctest-modules --junitxml=tests/net-util-test-results.xml
-#      - name: Upload net utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: net-util-test-results
-#          path: tests/net-util-test-results.xml
-#
-#      - name: Test Search Utils
-#        run: |
-#          pytest tests/search_util_tests.py --doctest-modules --junitxml=tests/search-util-test-results.xml
-#      - name: Upload search utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: search-util-test-results
-#          path: tests/search-util-test-results.xml
-#
-#      - name: Test Location Utils
-#        run: |
-#          pytest tests/location_util_tests.py --doctest-modules --junitxml=tests/location-util-test-results.xml
-#      - name: Upload location utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: location-util-test-results
-#          path: tests/location-util-test-results.xml
-#
-#      - name: Test Configuration Utils
-#        run: |
-#          pytest tests/configuration_util_tests.py --doctest-modules --junitxml=tests/configuration-util-test-results.xml
-#      - name: Upload configuration utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: configuration-util-test-results
-#          path: tests/configuration-util-test-results.xml
-#
-#      - name: Test Message Utils
-#        run: |
-#          pytest tests/message_util_tests.py --doctest-modules --junitxml=tests/message-util-test-results.xml
-#      - name: Upload message utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: message-util-test-results
-#          path: tests/message-util-test-results.xml
-#
-#      - name: Test Log Utils
-#        run: |
-#          pytest tests/log_util_tests.py --doctest-modules --junitxml=tests/log-util-test-results.xml
-#      - name: Upload log utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: log-util-test-results
-#          path: tests/log-util-test-results.xml
-#
-#      - name: Test Packaging Utils
-#        run: |
-#          pytest tests/packaging_util_tests.py --doctest-modules --junitxml=tests/packaging-util-test-results.xml
-#      - name: Upload packaging utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: packaging-util-test-results
-#          path: tests/packaging-util-test-results.xml
-#
-#      - name: Test Authentication Utils
-#        run: |
-#          pytest tests/authentication_util_tests.py --doctest-modules --junitxml=tests/authentication-util-test-results.xml
-#      - name: Upload authentication utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: authentication-util-test-results
-#          path: tests/authentication-util-test-results.xml
-#
-#      - name: Test Metric Utils
-#        run: |
-#          pytest tests/metric_util_tests.py --doctest-modules --junitxml=tests/metric-util-test-results.xml
-#      - name: Upload metric utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: metric-util-test-results
-#          path: tests/metric-util-test-results.xml
-#
-#      - name: Test Cache Utils
-#        run: |
-#          pytest tests/cache_util_tests.py --doctest-modules --junitxml=tests/cache-util-test-results.xml
-#      - name: Upload cache utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: cache-util-test-results
-#          path: tests/cache-util-test-results.xml
-#
-#      - name: Test MQ Utils
-#        run: |
-#          pytest tests/mq_util_tests.py --doctest-modules --junitxml=tests/mq-util-test-results.xml
-#      - name: Upload MQ utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: mq-util-test-results
-#          path: tests/mq-util-test-results.xml
-#
-#      - name: Test Validator Utils
-#        run: |
-#          pytest tests/validator_util_tests.py --doctest-modules --junitxml=tests/validator-util-test-results.xml
-#      - name: Upload validator utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: validator-util-test-results
-#          path: tests/validator-util-test-results.xml
-#
-#      - name: Test Signal Utils
-#        run: |
-#          pytest tests/signal_util_tests.py --doctest-modules --junitxml=tests/signal-util-test-results.xml
-#      - name: Upload signal utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: signal-util-test-results
-#          path: tests/signal-util-test-results.xml
-#
-#      - name: Test Messagebus Utils
-#        run: |
-#          pytest tests/messagebus_util_tests.py --doctest-modules --junitxml=tests/messagebus-util-test-results.xml
-#      - name: Upload messagebus utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: messagebus-util-test-results
-#          path: tests/messagebus-util-test-results.xml
-#
-#      - name: Test User Utils
-#        run: |
-#          pytest tests/user_util_tests.py --doctest-modules --junitxml=tests/user-util-test-results.xml
-#      - name: Upload user utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: user-util-test-results
-#          path: tests/user-util-test-results.xml
-#
-#      - name: Test Language Utils
-#        run: |
-#          pytest tests/language_util_tests.py --doctest-modules --junitxml=tests/language-util-test-results.xml
-#      - name: Upload language utils test results
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: language-util-test-results
-#          path: tests/language-util-test-results.xml
+
+      - name: Test Web Utils
+        run: |
+          pytest tests/web_util_tests.py --doctest-modules --junitxml=tests/web-util-test-results.xml
+      - name: Upload web utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-util-test-results
+          path: tests/web-util-test-results.xml
+
+      - name: Test Hana Utils
+        run: |
+          pytest tests/hana_util_tests.py --doctest-modules --junitxml=tests/hana-util-test-results.xml
+      - name: Upload hana utils test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: hana-util-test-results
+          path: tests/hana-util-test-results.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -213,17 +213,17 @@ jobs:
       - name: Upload user utils test results
         uses: actions/upload-artifact@v2
         with:
-          name: util-test-results
-          path: tests/util-test-results.xml
+          name: user-util-test-results
+          path: tests/user-util-test-results.xml
 
-      - name: Test Web Utils
+      - name: Test Language Utils
         run: |
-          pytest tests/web_util_tests.py --doctest-modules --junitxml=tests/web-util-test-results.xml
-      - name: Upload web utils test results
+          pytest tests/language_util_tests.py --doctest-modules --junitxml=tests/language-util-test-results.xml
+      - name: Upload language utils test results
         uses: actions/upload-artifact@v2
         with:
-          name: web-util-test-results
-          path: tests/web-util-test-results.xml
+          name: language-util-test-results
+          path: tests/language-util-test-results.xml
 
       - name: Test Hana Utils
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,164 +63,164 @@ jobs:
         run: |
           sudo chown -R nobody:nogroup tests/configuration/unwritable_path
 
-      - name: Test Parse Utils
+      - name: Test Utils
         run: |
-          pytest tests/parse_util_tests.py --doctest-modules --junitxml=tests/parse-util-test-results.xml
-      - name: Upload parse utils test results
+          pytest tests/ --doctest-modules --junitxml=tests/util-test-results.xml
+      - name: Upload utils test results
         uses: actions/upload-artifact@v2
         with:
-          name: parse-util-test-results
-          path: tests/parse-util-test-results.xml
-
-      - name: Test Web Utils
-        run: |
-          pytest tests/web_util_tests.py --doctest-modules --junitxml=tests/web-util-test-results.xml
-      - name: Upload web utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: web-util-test-results
-          path: tests/web-util-test-results.xml
-
-      - name: Test Net Utils
-        run: |
-          pytest tests/net_util_tests.py --doctest-modules --junitxml=tests/net-util-test-results.xml
-      - name: Upload net utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: net-util-test-results
-          path: tests/net-util-test-results.xml
-
-      - name: Test Search Utils
-        run: |
-          pytest tests/search_util_tests.py --doctest-modules --junitxml=tests/search-util-test-results.xml
-      - name: Upload search utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: search-util-test-results
-          path: tests/search-util-test-results.xml
-
-      - name: Test Location Utils
-        run: |
-          pytest tests/location_util_tests.py --doctest-modules --junitxml=tests/location-util-test-results.xml
-      - name: Upload location utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: location-util-test-results
-          path: tests/location-util-test-results.xml
-
-      - name: Test Configuration Utils
-        run: |
-          pytest tests/configuration_util_tests.py --doctest-modules --junitxml=tests/configuration-util-test-results.xml
-      - name: Upload configuration utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: configuration-util-test-results
-          path: tests/configuration-util-test-results.xml
-
-      - name: Test Message Utils
-        run: |
-          pytest tests/message_util_tests.py --doctest-modules --junitxml=tests/message-util-test-results.xml
-      - name: Upload message utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: message-util-test-results
-          path: tests/message-util-test-results.xml
-
-      - name: Test Log Utils
-        run: |
-          pytest tests/log_util_tests.py --doctest-modules --junitxml=tests/log-util-test-results.xml
-      - name: Upload log utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: log-util-test-results
-          path: tests/log-util-test-results.xml
-
-      - name: Test Packaging Utils
-        run: |
-          pytest tests/packaging_util_tests.py --doctest-modules --junitxml=tests/packaging-util-test-results.xml
-      - name: Upload packaging utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: packaging-util-test-results
-          path: tests/packaging-util-test-results.xml
-
-      - name: Test Authentication Utils
-        run: |
-          pytest tests/authentication_util_tests.py --doctest-modules --junitxml=tests/authentication-util-test-results.xml
-      - name: Upload authentication utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: authentication-util-test-results
-          path: tests/authentication-util-test-results.xml
-
-      - name: Test Metric Utils
-        run: |
-          pytest tests/metric_util_tests.py --doctest-modules --junitxml=tests/metric-util-test-results.xml
-      - name: Upload metric utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: metric-util-test-results
-          path: tests/metric-util-test-results.xml
-
-      - name: Test Cache Utils
-        run: |
-          pytest tests/cache_util_tests.py --doctest-modules --junitxml=tests/cache-util-test-results.xml
-      - name: Upload cache utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: cache-util-test-results
-          path: tests/cache-util-test-results.xml
-
-      - name: Test MQ Utils
-        run: |
-          pytest tests/mq_util_tests.py --doctest-modules --junitxml=tests/mq-util-test-results.xml
-      - name: Upload MQ utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: mq-util-test-results
-          path: tests/mq-util-test-results.xml
-
-      - name: Test Validator Utils
-        run: |
-          pytest tests/validator_util_tests.py --doctest-modules --junitxml=tests/validator-util-test-results.xml
-      - name: Upload validator utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: validator-util-test-results
-          path: tests/validator-util-test-results.xml
-
-      - name: Test Signal Utils
-        run: |
-          pytest tests/signal_util_tests.py --doctest-modules --junitxml=tests/signal-util-test-results.xml
-      - name: Upload signal utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: signal-util-test-results
-          path: tests/signal-util-test-results.xml
-
-      - name: Test Messagebus Utils
-        run: |
-          pytest tests/messagebus_util_tests.py --doctest-modules --junitxml=tests/messagebus-util-test-results.xml
-      - name: Upload messagebus utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: messagebus-util-test-results
-          path: tests/messagebus-util-test-results.xml
-
-      - name: Test User Utils
-        run: |
-          pytest tests/user_util_tests.py --doctest-modules --junitxml=tests/user-util-test-results.xml
-      - name: Upload user utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: user-util-test-results
-          path: tests/user-util-test-results.xml
-
-      - name: Test Language Utils
-        run: |
-          pytest tests/language_util_tests.py --doctest-modules --junitxml=tests/language-util-test-results.xml
-      - name: Upload language utils test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: language-util-test-results
-          path: tests/language-util-test-results.xml
+          name: util-test-results
+          path: tests/util-test-results.xml
+#
+#      - name: Test Web Utils
+#        run: |
+#          pytest tests/web_util_tests.py --doctest-modules --junitxml=tests/web-util-test-results.xml
+#      - name: Upload web utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: web-util-test-results
+#          path: tests/web-util-test-results.xml
+#
+#      - name: Test Net Utils
+#        run: |
+#          pytest tests/net_util_tests.py --doctest-modules --junitxml=tests/net-util-test-results.xml
+#      - name: Upload net utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: net-util-test-results
+#          path: tests/net-util-test-results.xml
+#
+#      - name: Test Search Utils
+#        run: |
+#          pytest tests/search_util_tests.py --doctest-modules --junitxml=tests/search-util-test-results.xml
+#      - name: Upload search utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: search-util-test-results
+#          path: tests/search-util-test-results.xml
+#
+#      - name: Test Location Utils
+#        run: |
+#          pytest tests/location_util_tests.py --doctest-modules --junitxml=tests/location-util-test-results.xml
+#      - name: Upload location utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: location-util-test-results
+#          path: tests/location-util-test-results.xml
+#
+#      - name: Test Configuration Utils
+#        run: |
+#          pytest tests/configuration_util_tests.py --doctest-modules --junitxml=tests/configuration-util-test-results.xml
+#      - name: Upload configuration utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: configuration-util-test-results
+#          path: tests/configuration-util-test-results.xml
+#
+#      - name: Test Message Utils
+#        run: |
+#          pytest tests/message_util_tests.py --doctest-modules --junitxml=tests/message-util-test-results.xml
+#      - name: Upload message utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: message-util-test-results
+#          path: tests/message-util-test-results.xml
+#
+#      - name: Test Log Utils
+#        run: |
+#          pytest tests/log_util_tests.py --doctest-modules --junitxml=tests/log-util-test-results.xml
+#      - name: Upload log utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: log-util-test-results
+#          path: tests/log-util-test-results.xml
+#
+#      - name: Test Packaging Utils
+#        run: |
+#          pytest tests/packaging_util_tests.py --doctest-modules --junitxml=tests/packaging-util-test-results.xml
+#      - name: Upload packaging utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: packaging-util-test-results
+#          path: tests/packaging-util-test-results.xml
+#
+#      - name: Test Authentication Utils
+#        run: |
+#          pytest tests/authentication_util_tests.py --doctest-modules --junitxml=tests/authentication-util-test-results.xml
+#      - name: Upload authentication utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: authentication-util-test-results
+#          path: tests/authentication-util-test-results.xml
+#
+#      - name: Test Metric Utils
+#        run: |
+#          pytest tests/metric_util_tests.py --doctest-modules --junitxml=tests/metric-util-test-results.xml
+#      - name: Upload metric utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: metric-util-test-results
+#          path: tests/metric-util-test-results.xml
+#
+#      - name: Test Cache Utils
+#        run: |
+#          pytest tests/cache_util_tests.py --doctest-modules --junitxml=tests/cache-util-test-results.xml
+#      - name: Upload cache utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: cache-util-test-results
+#          path: tests/cache-util-test-results.xml
+#
+#      - name: Test MQ Utils
+#        run: |
+#          pytest tests/mq_util_tests.py --doctest-modules --junitxml=tests/mq-util-test-results.xml
+#      - name: Upload MQ utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: mq-util-test-results
+#          path: tests/mq-util-test-results.xml
+#
+#      - name: Test Validator Utils
+#        run: |
+#          pytest tests/validator_util_tests.py --doctest-modules --junitxml=tests/validator-util-test-results.xml
+#      - name: Upload validator utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: validator-util-test-results
+#          path: tests/validator-util-test-results.xml
+#
+#      - name: Test Signal Utils
+#        run: |
+#          pytest tests/signal_util_tests.py --doctest-modules --junitxml=tests/signal-util-test-results.xml
+#      - name: Upload signal utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: signal-util-test-results
+#          path: tests/signal-util-test-results.xml
+#
+#      - name: Test Messagebus Utils
+#        run: |
+#          pytest tests/messagebus_util_tests.py --doctest-modules --junitxml=tests/messagebus-util-test-results.xml
+#      - name: Upload messagebus utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: messagebus-util-test-results
+#          path: tests/messagebus-util-test-results.xml
+#
+#      - name: Test User Utils
+#        run: |
+#          pytest tests/user_util_tests.py --doctest-modules --junitxml=tests/user-util-test-results.xml
+#      - name: Upload user utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: user-util-test-results
+#          path: tests/user-util-test-results.xml
+#
+#      - name: Test Language Utils
+#        run: |
+#          pytest tests/language_util_tests.py --doctest-modules --junitxml=tests/language-util-test-results.xml
+#      - name: Upload language utils test results
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: language-util-test-results
+#          path: tests/language-util-test-results.xml

--- a/neon_utils/hana_utils.py
+++ b/neon_utils/hana_utils.py
@@ -1,0 +1,139 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import requests
+import json
+
+from os.path import join, isfile
+from time import time
+from typing import Optional
+from ovos_utils.log import LOG
+from ovos_utils.xdg_utils import xdg_cache_home
+
+_client_config = {}
+_client_config_path = join(xdg_cache_home(), "neon", "hana_token.json")
+_headers = {}
+
+
+class ServerException(Exception):
+    """Exception class representing a backend server communication error"""
+
+
+def _init_client(backend_address: str):
+    """
+    Initialize request headers for making backend requests. If a local cache is
+    available it will be used, otherwise an auth request will be made to the
+    specified backend server
+    @param backend_address: Hana server URL to connect to
+    """
+    global _client_config
+    global _headers
+
+    if not _client_config:
+        if isfile(_client_config_path):
+            with open(_client_config_path) as f:
+                _client_config = json.load(f)
+        else:
+            get_token(backend_address)
+
+    if not _headers:
+        _headers = {"Authorization": f"Bearer {_client_config['access_token']}"}
+
+
+def get_token(backend_address: str, username: str = "guest",
+              password: str = "password"):
+    """
+    Get new auth tokens from the specified server. This will cache the returned
+    token, overwriting any previous data at the cache path.
+    @param backend_address: Hana server URL to connect to
+    @param username: Username to authorize
+    @param password: Password for specified username
+    """
+    global _client_config
+    # TODO: username/password from configuration
+    resp = requests.post(f"{backend_address}/auth/login",
+                         json={"username": username,
+                               "password": password})
+    if not resp.ok:
+        raise ServerException(f"Error logging into {backend_address}. "
+                              f"{resp.status_code}: {resp.text}")
+    _client_config = resp.json()
+    with open(_client_config_path, "w+") as f:
+        json.dump(_client_config, f, indent=2)
+
+
+def refresh_token(backend_address: str):
+    """
+    Get new tokens from the specified server using an existing refresh token
+    (if it exists). This will update the cached tokens and associated metadata.
+    @param backend_address: Hana server URL to connect to
+    """
+    global _client_config
+    _init_client(backend_address)
+    update = requests.post(f"{backend_address}/auth/refresh", json={
+        "access_token": _client_config.get("access_token"),
+        "refresh_token": _client_config.get("refresh_token"),
+        "client_id": _client_config.get("client_id")})
+    if not update.ok:
+        raise ServerException(f"Error updating token from {backend_address}. "
+                              f"{update.status_code}: {update.text}")
+    _client_config = update.json()
+    with open(_client_config_path, "w+") as f:
+        json.dump(_client_config, f, indent=2)
+
+
+def request_backend(endpoint: str, request_data: dict,
+                    server_config: Optional[dict] = None) -> dict:
+    """
+    Make a request to a Hana backend server and return the json response
+    @param endpoint: server endpoint to query
+    @param request_data: dict data to send in request body
+    @param server_config: Configuration['server']. If None, this will be read
+        from configuration
+    @returns: dict response
+    """
+    if not server_config:
+        from ovos_config.config import Configuration
+        server_config = Configuration().get("server", {})
+    if not server_config.get("backend_type") == "hana":
+        backend_address = "https://hana.neonaialpha.com"
+    else:
+        backend_address = server_config.get("url")
+    _init_client(backend_address)
+    if time() >= _client_config.get("expiration", 0):
+        try:
+            refresh_token(backend_address)
+        except ServerException as e:
+            LOG.error(e)
+            get_token(backend_address)
+    resp = requests.post(f"{backend_address}/{endpoint.lstrip('/')}",
+                         json=request_data, headers=_headers)
+    if resp.ok:
+        return resp.json()
+    else:
+        raise ServerException(f"Error response {resp.status_code}: {resp.text}")

--- a/neon_utils/hana_utils.py
+++ b/neon_utils/hana_utils.py
@@ -109,30 +109,22 @@ def _refresh_token(backend_address: str):
 
 
 def request_backend(endpoint: str, request_data: dict,
-                    server_config: Optional[dict] = None) -> dict:
+                    server_url: str = _DEFAULT_BACKEND_URL) -> dict:
     """
     Make a request to a Hana backend server and return the json response
     @param endpoint: server endpoint to query
     @param request_data: dict data to send in request body
-    @param server_config: Configuration['server']. If None, this will be read
-        from configuration
+    @param server_url: Base URL of Hana server to query
     @returns: dict response
     """
-    if not server_config:
-        from ovos_config.config import Configuration
-        server_config = Configuration().get("server", {})
-    if server_config.get("backend_type") == "hana":
-        backend_address = server_config.get("url")
-    else:
-        backend_address = _DEFAULT_BACKEND_URL
-    _init_client(backend_address)
+    _init_client(server_url)
     if time() >= _client_config.get("expiration", 0):
         try:
-            _refresh_token(backend_address)
+            _refresh_token(server_url)
         except ServerException as e:
             LOG.error(e)
-            _get_token(backend_address)
-    resp = requests.post(f"{backend_address}/{endpoint.lstrip('/')}",
+            _get_token(server_url)
+    resp = requests.post(f"{server_url}/{endpoint.lstrip('/')}",
                          json=request_data, headers=_headers)
     if resp.ok:
         return resp.json()

--- a/neon_utils/hana_utils.py
+++ b/neon_utils/hana_utils.py
@@ -59,14 +59,14 @@ def _init_client(backend_address: str):
             with open(_client_config_path) as f:
                 _client_config = json.load(f)
         else:
-            get_token(backend_address)
+            _get_token(backend_address)
 
     if not _headers:
         _headers = {"Authorization": f"Bearer {_client_config['access_token']}"}
 
 
-def get_token(backend_address: str, username: str = "guest",
-              password: str = "password"):
+def _get_token(backend_address: str, username: str = "guest",
+               password: str = "password"):
     """
     Get new auth tokens from the specified server. This will cache the returned
     token, overwriting any previous data at the cache path.
@@ -87,7 +87,7 @@ def get_token(backend_address: str, username: str = "guest",
         json.dump(_client_config, f, indent=2)
 
 
-def refresh_token(backend_address: str):
+def _refresh_token(backend_address: str):
     """
     Get new tokens from the specified server using an existing refresh token
     (if it exists). This will update the cached tokens and associated metadata.
@@ -127,10 +127,10 @@ def request_backend(endpoint: str, request_data: dict,
     _init_client(backend_address)
     if time() >= _client_config.get("expiration", 0):
         try:
-            refresh_token(backend_address)
+            _refresh_token(backend_address)
         except ServerException as e:
             LOG.error(e)
-            get_token(backend_address)
+            _get_token(backend_address)
     resp = requests.post(f"{backend_address}/{endpoint.lstrip('/')}",
                          json=request_data, headers=_headers)
     if resp.ok:

--- a/neon_utils/hana_utils.py
+++ b/neon_utils/hana_utils.py
@@ -35,6 +35,7 @@ from typing import Optional
 from ovos_utils.log import LOG
 from ovos_utils.xdg_utils import xdg_cache_home
 
+_DEFAULT_BACKEND_URL = "https://hana.neonaialpha.com"
 _client_config = {}
 _client_config_path = join(xdg_cache_home(), "neon", "hana_token.json")
 _headers = {}
@@ -120,10 +121,10 @@ def request_backend(endpoint: str, request_data: dict,
     if not server_config:
         from ovos_config.config import Configuration
         server_config = Configuration().get("server", {})
-    if not server_config.get("backend_type") == "hana":
-        backend_address = "https://hana.neonaialpha.com"
-    else:
+    if server_config.get("backend_type") == "hana":
         backend_address = server_config.get("url")
+    else:
+        backend_address = _DEFAULT_BACKEND_URL
     _init_client(backend_address)
     if time() >= _client_config.get("expiration", 0):
         try:

--- a/tests/hana_util_tests.py
+++ b/tests/hana_util_tests.py
@@ -60,14 +60,11 @@ class HanaUtilTests(unittest.TestCase):
         import neon_utils.hana_utils
         neon_utils.hana_utils._client_config = valid_config
         neon_utils.hana_utils._headers = valid_headers
-
-        server_config = {"backend_type": "hana",
-                         "url": self.test_server}
         from neon_utils.hana_utils import request_backend
         resp = request_backend("/neon/get_response",
                                {"lang_code": "en-us",
                                 "utterance": "who are you",
-                                "user_profile": {}}, server_config)
+                                "user_profile": {}}, self.test_server)
         self.assertEqual(resp['lang_code'], "en-us")
         self.assertIsInstance(resp['answer'], str)
         # TODO: Test invalid route, invalid request data

--- a/tests/hana_util_tests.py
+++ b/tests/hana_util_tests.py
@@ -73,10 +73,10 @@ class HanaUtilTests(unittest.TestCase):
         # TODO: Test invalid route, invalid request data
 
     def test_00_get_token(self):
-        from neon_utils.hana_utils import get_token
+        from neon_utils.hana_utils import _get_token
 
         # Test valid request
-        get_token(self.test_server)
+        _get_token(self.test_server)
         from neon_utils.hana_utils import _client_config
         self.assertTrue(isfile(self.test_path))
         with open(self.test_path) as f:
@@ -93,13 +93,13 @@ class HanaUtilTests(unittest.TestCase):
                 json.dump(valid_config, c)
             neon_utils.hana_utils._client_config = valid_config
 
-        from neon_utils.hana_utils import refresh_token
+        from neon_utils.hana_utils import _refresh_token
         get_token.side_effect = _write_token
 
         self.assertFalse(isfile(self.test_path))
 
         # Test valid request (auth + refresh)
-        refresh_token(self.test_server)
+        _refresh_token(self.test_server)
         get_token.assert_called_once()
         from neon_utils.hana_utils import _client_config
         self.assertTrue(isfile(self.test_path))
@@ -108,7 +108,7 @@ class HanaUtilTests(unittest.TestCase):
         self.assertEqual(credentials_on_disk, _client_config)
 
         # Test refresh of existing token (no auth)
-        refresh_token(self.test_server)
+        _refresh_token(self.test_server)
         get_token.assert_called_once()
         with open(self.test_path) as f:
             new_credentials = json.load(f)

--- a/tests/hana_util_tests.py
+++ b/tests/hana_util_tests.py
@@ -1,0 +1,102 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+import unittest
+from os import remove
+from os.path import join, dirname, isfile
+
+
+class HanaUtilTests(unittest.TestCase):
+    import neon_utils.hana_utils
+    test_server = "https://hana.neonaialpha.com"
+    test_path = join(dirname(__file__), "hana_test.json")
+    neon_utils.hana_utils._client_config_path = test_path
+
+    def tearDown(self) -> None:
+        import neon_utils.hana_utils
+        if isfile(self.test_path):
+            remove(self.test_path)
+        neon_utils.hana_utils._client_config = {}
+        neon_utils.hana_utils._headers = {}
+
+    def test_request_backend(self):
+        server_config = {"backend_type": "hana",
+                         "url": self.test_server}
+        from neon_utils.hana_utils import request_backend
+        resp = request_backend("/neon/get_response",
+                               {"lang_code": "en-us",
+                                "utterance": "who are you",
+                                "user_profile": {}}, server_config)
+        self.assertEqual(resp['lang_code'], "en-us")
+        self.assertIsInstance(resp['answer'], str)
+        # TODO: Test invalid route, invalid request data
+
+    def test_get_token(self):
+        from neon_utils.hana_utils import get_token
+
+        # Test valid request
+        get_token(self.test_server)
+        from neon_utils.hana_utils import _client_config
+        self.assertTrue(isfile(self.test_path))
+        with open(self.test_path) as f:
+            credentials_on_disk = json.load(f)
+        self.assertEqual(credentials_on_disk, _client_config)
+        # TODO: Test invalid request, rate-limited request
+
+    def test_refresh_token(self):
+        from neon_utils.hana_utils import refresh_token
+
+        # Test valid request (auth + refresh)
+        refresh_token(self.test_server)
+        from neon_utils.hana_utils import _client_config
+        self.assertTrue(isfile(self.test_path))
+        with open(self.test_path) as f:
+            credentials_on_disk = json.load(f)
+        self.assertEqual(credentials_on_disk, _client_config)
+
+        # Test refresh of existing token (no auth)
+        refresh_token(self.test_server)
+        with open(self.test_path) as f:
+            new_credentials = json.load(f)
+        self.assertNotEqual(credentials_on_disk, new_credentials)
+        self.assertEqual(credentials_on_disk['client_id'],
+                         new_credentials['client_id'])
+        self.assertEqual(credentials_on_disk['username'],
+                         new_credentials['username'])
+        self.assertGreater(new_credentials['expiration'],
+                           credentials_on_disk['expiration'])
+        self.assertNotEqual(credentials_on_disk['access_token'],
+                            new_credentials['access_token'])
+        self.assertNotEqual(credentials_on_disk['refresh_token'],
+                            new_credentials['refresh_token'])
+
+        # TODO: Test invalid refresh
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/hana_util_tests.py
+++ b/tests/hana_util_tests.py
@@ -81,7 +81,7 @@ class HanaUtilTests(unittest.TestCase):
         self.assertEqual(credentials_on_disk, _client_config)
         # TODO: Test invalid request, rate-limited request
 
-    @patch("neon_utils.hana_utils.get_token")
+    @patch("neon_utils.hana_utils._get_token")
     def test_refresh_token(self, get_token):
         import neon_utils.hana_utils
 


### PR DESCRIPTION
# Description
Add `hana_utils` with unit tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Eventually, Hana should be integrated with `ovos-backend-client` but until then this will not assume any Configuration changes as it should ideally use `server ` config which is parsed by `ovos-backend-client`. For the moment, the module has a valid hard-coded server reference and accepts a URL argument so callers may choose how to specify a server address