### PR TITLE
Add function to get installed prerelease packages

### DIFF
--- a/neon_utils/packaging_utils.py
+++ b/neon_utils/packaging_utils.py
@@ -291,6 +291,8 @@ def get_installed_prereleases() -> List[Tuple[str, str]]:
         if not line:
             continue
         name, version = line.split()
+        if name == "Package" or not name.replace('-', ''):
+            continue
         if not version.replace('.', '').isnumeric():
             if "post" in version:
                 LOG.debug(f"post release {name}:{version}")

--- a/tests/packaging_util_tests.py
+++ b/tests/packaging_util_tests.py
@@ -175,7 +175,9 @@ class PackagingUtilTests(unittest.TestCase):
 
     @patch("subprocess.run")
     def test_get_installed_prereleases(self, run):
-        run.return_value.stdout = """stable_package          1.0.0
+        run.return_value.stdout = """Package        Version
+----------------------- ------------
+stable_package          1.0.0
 beta_package            0.2.2b3
 alpha_package           0.0.0a0
 date_package            24.4.30


### PR DESCRIPTION
# Description
Adds a method to get a list of installed pre-release packages. This can be used in automation to validate a stable release is not pulling any alpha packages

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->