### PR TITLE
Add backwards-compat import to `neon_fallback_skill` module

### DIFF
--- a/neon_utils/skills/neon_fallback_skill.py
+++ b/neon_utils/skills/neon_fallback_skill.py
@@ -53,7 +53,7 @@ from neon_utils.cache_utils import LRUCache
 from neon_utils.file_utils import resolve_neon_resource_file
 from neon_utils.location_utils import to_system_time
 from neon_utils.message_utils import dig_for_message, resolve_message, get_message_user
-from neon_utils.skills.neon_skill import CACHE_TIME_OFFSET, DEFAULT_SPEED_MODE, SPEED_MODE_EXTENSION_TIME
+from neon_utils.skills.neon_skill import CACHE_TIME_OFFSET, DEFAULT_SPEED_MODE, SPEED_MODE_EXTENSION_TIME, NeonSkill
 from neon_utils.user_utils import get_user_prefs
 
 


### PR DESCRIPTION
# Description
Add `NeonSkill` import for backwards-compat

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Resolves import error in LLM fallback skill https://github.com/NeonGeckoCom/skill-fallback_llm/blob/94f2d5613076bc827f57a01d96c2d3c74ac1dea6/__init__.py#L38