### PR TITLE
Enable `hana` backend URL to be configured

### DIFF
--- a/neon_utils/hana_utils.py
+++ b/neon_utils/hana_utils.py
@@ -152,7 +152,7 @@ def request_backend(endpoint: str, request_data: dict,
         set_default_backend_url()
         server_url = _DEFAULT_BACKEND_URL
     if server_url != _DEFAULT_BACKEND_URL and _client_config:
-        LOG.warning(f"Using new remote: {server_url}")
+        LOG.info(f"Using new remote: {server_url}")
         _client_config = {}
         _headers = {}
     _init_client(server_url)

--- a/neon_utils/hana_utils.py
+++ b/neon_utils/hana_utils.py
@@ -29,18 +29,38 @@
 import requests
 import json
 
+from typing import Optional
 from os import makedirs
 from os.path import join, isfile, isdir, dirname
 from time import time
 from ovos_utils.log import LOG
 from ovos_utils.xdg_utils import xdg_cache_home
 
-_DEFAULT_BACKEND_URL = "https://hana.neonaiservices.com"
+_DEFAULT_BACKEND_URL = None
 _client_config = {}
 _headers = {}
 
 
-def _get_client_config_path(url: str = _DEFAULT_BACKEND_URL):
+def set_default_backend_url(url: Optional[str] = None):
+    """
+    Set the default backend URL
+    @param url: HANA backend url to use, else read from configuration
+    """
+    global _DEFAULT_BACKEND_URL
+    if not url:
+        from ovos_config.config import Configuration
+        url = Configuration().get('hana', {}).get('url') or \
+            "https://hana.neonaiservices.com"
+    if url and url != _DEFAULT_BACKEND_URL:
+        LOG.info(f"Updating HANA backend URL to {url}")
+        _DEFAULT_BACKEND_URL = url
+        global _client_config
+        global _headers
+        _client_config = {}
+        _headers = {}
+
+
+def _get_client_config_path(url: str):
     url_key = hash(url)
     return join(xdg_cache_home(), "neon", f"hana_token_{url_key}.json")
 
@@ -126,6 +146,15 @@ def request_backend(endpoint: str, request_data: dict,
     @param server_url: Base URL of Hana server to query
     @returns: dict response
     """
+    global _client_config
+    global _headers
+    if not server_url:
+        set_default_backend_url()
+        server_url = _DEFAULT_BACKEND_URL
+    if server_url != _DEFAULT_BACKEND_URL and _client_config:
+        LOG.warning(f"Using new remote: {server_url}")
+        _client_config = {}
+        _headers = {}
     _init_client(server_url)
     if time() >= _client_config.get("expiration", 0):
         try:

--- a/tests/hana_util_tests.py
+++ b/tests/hana_util_tests.py
@@ -135,6 +135,25 @@ class HanaUtilTests(unittest.TestCase):
 
         # TODO: Test invalid refresh
 
+    @patch("ovos_config.config.Configuration")
+    def test_set_default_backend_url(self, config):
+        import neon_utils.hana_utils
+        from neon_utils.hana_utils import set_default_backend_url
+        neon_utils.hana_utils._DEFAULT_BACKEND_URL = None
+        config.return_value = dict()
+
+        set_default_backend_url()
+        self.assertEqual(neon_utils.hana_utils._DEFAULT_BACKEND_URL,
+                         "https://hana.neonaiservices.com")
+
+        set_default_backend_url("https://hana.neonaialpha.com")
+        self.assertEqual(neon_utils.hana_utils._DEFAULT_BACKEND_URL,
+                         "https://hana.neonaialpha.com")
+
+        set_default_backend_url()
+        self.assertEqual(neon_utils.hana_utils._DEFAULT_BACKEND_URL,
+                         "https://hana.neonaiservices.com")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/hana_util_tests.py
+++ b/tests/hana_util_tests.py
@@ -129,7 +129,7 @@ class HanaUtilTests(unittest.TestCase):
     def test_config_path(self):
         from neon_utils.hana_utils import _get_client_config_path
         path_1 = _get_client_config_path("https://hana.neonaialpha.com")
-        default = _get_client_config_path()
+        default = _get_client_config_path("https://hana.neonaiservices.com")
         self.assertNotEqual(path_1, default)
         self.assertEqual(dirname(path_1), dirname(default))
 


### PR DESCRIPTION
# Description
Update to read default `hana` backend URL from configuration

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->