### PR TITLE
Refactor to use pytz instead of pendulum

### DIFF
--- a/neon_utils/location_utils.py
+++ b/neon_utils/location_utils.py
@@ -26,10 +26,11 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pendulum
+import pytz
 
 from datetime import datetime
 from typing import Optional, Union
+
 from dateutil.tz import tzlocal
 from timezonefinder import TimezoneFinder
 from re import sub
@@ -143,10 +144,10 @@ def get_timezone(lat, lng) -> (str, float):
     Note that some coordinates do not have a city, but may have a county.
     :param lat: latitude
     :param lng: longitude
-    :return: timezone name, offset from GMT
+    :return: timezone name, offset in hours from UTC
     """
     timezone = TimezoneFinder().timezone_at(lng=float(lng), lat=float(lat))
-    offset = pendulum.from_timestamp(0, timezone).offset_hours
+    offset = pytz.timezone(timezone).utcoffset(datetime.utcnow()).seconds / 3600.0
     return timezone, offset
 
 

--- a/neon_utils/location_utils.py
+++ b/neon_utils/location_utils.py
@@ -25,6 +25,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from time import time
 
 import pytz
 
@@ -147,7 +148,10 @@ def get_timezone(lat, lng) -> (str, float):
     :return: timezone name, offset in hours from UTC
     """
     timezone = TimezoneFinder().timezone_at(lng=float(lng), lat=float(lat))
-    offset = pytz.timezone(timezone).utcoffset(datetime.utcnow()).seconds / 3600.0
+    _time = time()
+    utc_timestamp = datetime.utcfromtimestamp(_time).timestamp()
+    local_timestamp = datetime.fromtimestamp(_time, tz=pytz.timezone(timezone)).timestamp()
+    offset = (local_timestamp - utc_timestamp) / 3600
     return timezone, offset
 
 

--- a/neon_utils/location_utils.py
+++ b/neon_utils/location_utils.py
@@ -148,10 +148,8 @@ def get_timezone(lat, lng) -> (str, float):
     :return: timezone name, offset in hours from UTC
     """
     timezone = TimezoneFinder().timezone_at(lng=float(lng), lat=float(lat))
-    _time = time()
-    utc_timestamp = datetime.utcfromtimestamp(_time).timestamp()
-    local_timestamp = datetime.fromtimestamp(_time, tz=pytz.timezone(timezone)).timestamp()
-    offset = (local_timestamp - utc_timestamp) / 3600
+    offset = pytz.timezone(timezone).utcoffset(
+        datetime.now()).total_seconds() / 3600
     return timezone, offset
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 ovos-bus-client~=0.0.3
 combo-lock~=0.2
-pendulum~=2.1
+pytz>=2022.1
 timezonefinder~=5.2
 nltk~=3.5
 pyyaml>=5.4,<7.0

--- a/tests/location_util_tests.py
+++ b/tests/location_util_tests.py
@@ -88,6 +88,12 @@ class LocationUtilTests(unittest.TestCase):
         self.assertIsInstance(offset, float)
         self.assertIn(offset, (-7.0, -8.0))
 
+        lat = 35.0000
+        lon = 103.000
+        timezone, offset = get_timezone(lat, lon)
+        self.assertEqual(timezone, "Asia/Shanghai")
+        self.assertEqual(offset, 8.0)
+
     def test_to_system_time(self):
         from neon_utils.location_utils import to_system_time
         tz_aware_dt = datetime.now(gettz("America/NewYork"))


### PR DESCRIPTION
# Description
Refactor location_utils to use `pytz` instead of `pendulum`

# Issues
Relates to https://github.com/NeonGeckoCom/pyklatchat/pull/96
Unrelated test failures fixed by https://github.com/NeonGeckoCom/neon-utils/pull/528

# Other Notes
`pytz` is already used in `skill-date_time` among other places, so this removes a dependency in most distributions. 