### PR TITLE
Update Python versions in tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
   skill_object_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
+        python-version: [ 3.8, 3.9, '3.10', '3.11' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
+        python-version: [ 3.8, 3.9, '3.10', '3.11' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
   skill_object_tests:
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description
Update tests to remove Python 3.7 and add 3.11-3.12
Updates hana tests to account for backend fix: https://github.com/NeonGeckoCom/neon-hana/pull/35

# Issues
Test failures related to deprecation noted in https://github.com/NeonGeckoCom/neon-utils/pull/539

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->