### PR TITLE
Update unit test automation for Python 3.12 support

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,17 +11,17 @@ jobs:
   skill_object_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, '3.10', '3.11' ]
+        python-version: [ 3.9, '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install wheel "cython<3.0.0"  # TODO: cython patching https://github.com/yaml/pyyaml/issues/724
           pip install --no-build-isolation pyyaml~=5.4  # TODO: patching https://github.com/yaml/pyyaml/issues/724
           sudo apt update
@@ -39,23 +39,23 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, '3.10', '3.11' ]
+        python-version: [ 3.9, '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Sound Library
         run: |
           sudo apt-get update
           sudo apt-get install libsndfile1
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install gcc libfann-dev
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install wheel "cython<3.0.0"  # TODO: cython patching https://github.com/yaml/pyyaml/issues/724
           pip install --no-build-isolation pyyaml~=5.4  # TODO: patching https://github.com/yaml/pyyaml/issues/724
           pip install .[test,audio,network,configuration]


### PR DESCRIPTION
# Description
Update Python versions in unit tests to remove 3.8 and add 3.12
Update shared actions to latest versions
Add `setuptools` installation to test automation for Python3.12 support

# Issues
Closes #542 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->