### PR TITLE
Refactor deprecated import

### DIFF
--- a/neon_utils/metrics_utils.py
+++ b/neon_utils/metrics_utils.py
@@ -106,7 +106,7 @@ def report_metric(name: str, **kwargs):
 
 def announce_connection():
     try:
-        from neon_utils.mq_utils import send_mq_request
+        from neon_mq_connector.utils.client_utils import send_mq_request
         from neon_core.version import __version__
         from ovos_config.config import Configuration
         data = {"time": strftime('%Y-%m-%d %H:%M:%S'),


### PR DESCRIPTION
# Description
Refactor `neon_utils.mq_utils` import to import from defining module

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Resolves logged deprecation warnings on Mark2