### PR TITLE
Add helper to start a health check server

### DIFF
--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -98,11 +98,11 @@ def start_health_check_server(
 
     class HealthCheckHandler(BaseHTTPRequestHandler):
         def do_GET(self):
-            if self.status_callback is not None:
+            if self.server.status_callback is not None:
                 try:
-                    self.status_callback()
+                    self.server.status_callback()
                 except Exception as e:
-                    self.service_status.set_error(str(e))
+                    self.server.service_status.set_error(str(e))
             if self.path == "/status":
                 if self.server.service_status.state == ProcessState.NOT_STARTED:
                     resp_code = 503

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -91,7 +91,14 @@ def start_health_check_server(
 ) -> Thread:
     """
     Starts an HTTP server to report the status of a module that implements a
-    ProcessStatus object.
+    ProcessStatus object. A specified `status_callback` is expected to modify
+    the `service_status` object as any returned value is ignored. If the
+    `status_callback` raises an exception, the `service_status` will be
+    updated here to set the error state.
+
+    :param service_status: ProcessStatus object to get status from
+    :param port: Port to run the health check server on
+    :param status_callback: Optional callback to run on each health check
     """
     import json
     from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -96,8 +96,8 @@ def start_health_check_server(
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
     class HealthCheckHandler(BaseHTTPRequestHandler):
+        service_status: ProcessStatus = None
         def __init__(self, *args, **kwargs):
-            self.service_status: ProcessStatus = kwargs.pop("service_status")
             BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
 
         def do_GET(self):
@@ -149,9 +149,8 @@ def start_health_check_server(
                 self.send_response(404)
                 self.end_headers()
 
-    server = HTTPServer(
-        ("0.0.0.0", port), HealthCheckHandler, service_status=service_status
-    )
+    HealthCheckHandler.service_status = service_status
+    server = HTTPServer(("0.0.0.0", port), HealthCheckHandler)
     thread = Thread(server.serve_forever, daemon=True)
     thread.start()
     LOG.info(f"Started health check endpoint at {server.server_address}")

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -85,7 +85,9 @@ def start_systemd_service(service: callable, **kwargs):
     )
 
 
-def start_health_check_server(service_status: ProcessStatus, port: int = 8000) -> Thread:
+def start_health_check_server(
+    service_status: ProcessStatus, port: int = 8000
+) -> Thread:
     """
     Starts an HTTP server to report the status of a module that implements a
     ProcessStatus object.
@@ -98,7 +100,6 @@ def start_health_check_server(service_status: ProcessStatus, port: int = 8000) -
             self.service_status: ProcessStatus = kwargs.pop("service_status")
             BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
 
-            
         def do_GET(self):
             if self.path == "/health":
                 if self.service_status.state == ProcessState.NOT_STARTED:
@@ -148,12 +149,14 @@ def start_health_check_server(service_status: ProcessStatus, port: int = 8000) -
                 self.send_response(404)
                 self.end_headers()
 
-
-    server = HTTPServer(("0.0.0.0", port), HealthCheckHandler, service_status=service_status)
+    server = HTTPServer(
+        ("0.0.0.0", port), HealthCheckHandler, service_status=service_status
+    )
     thread = Thread(server.serve_forever, daemon=True)
     thread.start()
     LOG.info(f"Started health check endpoint at {server.server_address}")
     return thread
+
 
 def start_malloc(
     config: dict = None, stack_depth: int = 1, force: bool = False

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -101,7 +101,7 @@ def start_health_check_server(
             BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
 
         def do_GET(self):
-            if self.path == "/health":
+            if self.path == "/status":
                 if self.service_status.state == ProcessState.NOT_STARTED:
                     resp_code = 503
                     content = "Service not started"

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -95,10 +95,10 @@ def start_health_check_server(
     import json
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
-    class HealthCheckHandler(BaseHTTPRequestHandler):
-        service_status: ProcessStatus = None
-        def __init__(self, *args, **kwargs):
-            BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
+    class HealthCheckHandler(HTTPServer):
+        def __init__(self, server_address, request_handler_class, service_status):
+            HTTPServer.__init__(self, server_address, request_handler_class)
+            self.service_status: ProcessStatus = service_status
 
         def do_GET(self):
             if self.path == "/status":
@@ -149,8 +149,7 @@ def start_health_check_server(
                 self.send_response(404)
                 self.end_headers()
 
-    HealthCheckHandler.service_status = service_status
-    server = HTTPServer(("0.0.0.0", port), HealthCheckHandler)
+    server = HealthCheckHandler(("0.0.0.0", port), HealthCheckHandler, service_status)
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     LOG.info(f"Started health check endpoint at {server.server_address}")

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -150,7 +150,7 @@ def start_health_check_server(
                 self.end_headers()
 
     server = HTTPServer(("0.0.0.0", port), HealthCheckHandler)
-    HealthCheckHandler.service_status = service_status
+    server.service_status = service_status
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     LOG.info(f"Started health check endpoint at {server.server_address}")

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -113,9 +113,6 @@ def start_health_check_server(
                 elif self.server.service_status.state == ProcessState.STOPPING:
                     resp_code = 503
                     content = "Stopping"
-                elif self.server.service_status.state == ProcessState.STOPPED:
-                    resp_code = 503
-                    content = "Stopped"
                 elif self.server.service_status.state == ProcessState.ERROR:
                     resp_code = 500
                     content = "Error"

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -96,48 +96,32 @@ def start_health_check_server(
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
     class HealthCheckHandler(BaseHTTPRequestHandler):
-        service_status: ProcessStatus = None
-        def __init__(self, *args, **kwargs):
-            BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
-
         def do_GET(self):
             if self.path == "/status":
-                if self.service_status.state == ProcessState.NOT_STARTED:
+                if self.server.service_status.state == ProcessState.NOT_STARTED:
                     resp_code = 503
                     content = "Service not started"
-                elif self.service_status.state == ProcessState.STARTED:
+                elif self.server.service_status.state == ProcessState.STARTED:
                     resp_code = 200
                     content = "Starting"
-                elif self.service_status.state == ProcessState.ALIVE:
+                elif self.server.service_status.state == ProcessState.ALIVE:
                     resp_code = 200
                     content = "Starting"
-                elif self.service_status.state == ProcessState.READY:
+                elif self.server.service_status.state == ProcessState.READY:
                     resp_code = 200
                     content = "Ready"
-                elif self.service_status.state == ProcessState.STOPPING:
+                elif self.server.service_status.state == ProcessState.STOPPING:
                     resp_code = 503
                     content = "Stopping"
-                elif self.service_status.state == ProcessState.STOPPED:
+                elif self.server.service_status.state == ProcessState.STOPPED:
                     resp_code = 503
                     content = "Stopped"
-                elif self.service_status.state == ProcessState.ERROR:
+                elif self.server.service_status.state == ProcessState.ERROR:
                     resp_code = 500
                     content = "Error"
                 else:
                     resp_code = 500
                     content = f"Unknown state: {self.service_status.state}"
-                self.service_status = (
-                    self.server.service_status
-                )  # Assuming you pass this to the server
-                if self.service_status.state == ProcessState.ALIVE:
-                    resp_code = 200
-                    content = "Starting"
-                elif self.service_status.state == ProcessState.READY:
-                    resp_code = 200
-                    content = "Ready"
-                else:
-                    resp_code = 500
-                    content = "Error"
 
                 self.send_response(resp_code)
                 self.send_header("Content-Type", "application/json")

--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -151,7 +151,7 @@ def start_health_check_server(
 
     HealthCheckHandler.service_status = service_status
     server = HTTPServer(("0.0.0.0", port), HealthCheckHandler)
-    thread = Thread(server.serve_forever, daemon=True)
+    thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     LOG.info(f"Started health check endpoint at {server.server_address}")
     return thread


### PR DESCRIPTION
# Description
Implements a helper method to start an HTTP server with a `/status` endpoint based on ProcessState

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Helper method includes a `status_callback` kwarg which allows for specifying a method to be called before reporting service status (i.e. to perform additional checks that may change service status)