### PR TITLE
Override `/status` server endpoint logging

### DIFF
--- a/neon_utils/process_utils.py
+++ b/neon_utils/process_utils.py
@@ -104,6 +104,10 @@ def start_health_check_server(
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
     class HealthCheckHandler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            # Override logging to use LOG singleton
+            LOG.debug(format % args)
+
         def do_GET(self):
             if self.server.status_callback is not None:
                 try:


### PR DESCRIPTION
# Description
Override `/status` server endpoint logging to use configured `LOG` object
Prevents logging all status requests to stderr

# Issues
Follow-up to #551

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->