### PR TITLE
Update `ovos-utils` compat. changes

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,6 +39,7 @@ jobs:
           path: tests/skill-object-test-results.xml
   unit_tests:
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ 3.9, '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest

--- a/neon_utils/signal_utils.py
+++ b/neon_utils/signal_utils.py
@@ -141,6 +141,9 @@ def init_signal_handlers():
             import os
             import tempfile
             from ovos_utils.file_utils import ensure_directory_exists
+            log_deprecation("Import patching will be deprecated. Disable in "
+                "configuration by setting `signal`.`patch_imports` "
+                "to `False`", "2.0.0")
 
             def get_ipc_directory(domain=None, config=None):
                 """Get the directory used for Inter Process Communication

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ timezonefinder~=5.2
 nltk~=3.5
 pyyaml>=5.4,<7.0
 ovos-lingua-franca~=0.4
-ovos-utils~=0.0,>=0.0.35
+ovos-utils~=0.8,>=0.8.5
 geopy~=2.1
 ovos-config~=0.1
 ovos-workshop~=0.0,>=0.0.15


### PR DESCRIPTION
# Description
Replace deprecation warning removed in #562 
Explicitly require newer ovos-utils so patching of old installations isn't broken

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Anything relying on the patched methods in `ovos-utils` should pin an `ovos-utils` version that includes those methods; since this requires `ovos-utils` versions that deprecated those methods, it should not break anything requiring an older `ovos-utils` that needs patching