### PR TITLE
fix: register nltk download path before downloading cmudict

### DIFF
--- a/neon_utils/parse_utils.py
+++ b/neon_utils/parse_utils.py
@@ -122,8 +122,11 @@ def get_phonemes(phrase: str) -> str:
     download_path = os.path.expanduser("~/.local/share/neon")
     if not os.path.isdir(download_path):
         os.makedirs(download_path)
+    # nltk authorizes download targets against `nltk.data.path`, so the path
+    # must be registered before the download, not after
+    if download_path not in nltk.data.path:
+        nltk.data.path.append(download_path)
     nltk.download('cmudict', download_dir=download_path)
-    nltk.data.path.append(download_path)
 
     output = ''
     for word in phrase.split():


### PR DESCRIPTION
## Summary
The `unit_tests` workflow fails on `dev` at the Test Parse Utils step, on Python 3.10, 3.11, and 3.12. The failed test is `tests/parse_util_tests.py::ParseUtilTests::test_get_phonemes`.

The cause is a change in nltk 3.10, not a change in this repository. nltk added `nltk/pathsec.py`, which authorizes a download target against the directories in `nltk.data.path`. `get_phonemes` (`neon_utils/parse_utils.py:115`) registered its download directory one line after the download call:

```python
nltk.download('cmudict', download_dir=download_path)
nltk.data.path.append(download_path)
```

The download ran against a path that was not yet registered, so nltk refused it:

```
[nltk_data] Error downloading 'cmudict' ... Security Violation
[nltk_data] [Downloader._download_package]: Unauthorized path
[nltk_data] /home/runner/.local/share/neon/corpora/cmudict.zip.tmp
```

`cmudict` did not install. The corpus lookup then raised `LookupError`.

`requirements/requirements.txt` pins `nltk~=3.5`, which permits 3.10.2. The last `dev` run that passed was 2026-06-08, before this nltk release.

## Change
Register the download path before the download. The `in` test prevents duplicate entries in `nltk.data.path` on repeat calls.

## Test plan
- Reproduced the fault alone: `nltk.download('cmudict', download_dir=...)` returns `False` with the security violation above when the directory is absent from `nltk.data.path`. It returns `True` when the directory is present.
- Deleted the local corpus cache to get the same cold-cache state as CI. `test_get_phonemes` fails before this change and passes after it.
- `tests/parse_util_tests.py`: 15 passed from a cold cache.

## Note
This change is independent of #565. #565 starts from the same commit and shows the same CI fault, which this change corrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)